### PR TITLE
removed old changelog parsing; updated files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-include changelog
+include CHANGELOG.md
 include LICENSE
-include README.rst
+include README.md
 include requirements.txt
 include rfclint/run.py
 include rfclint/abnf.py

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 # Copyright The IETF Trust 2018-9, All Rights Reserved
 # ----------------------------------------------------
 
-import re
 import sys
 from setuptools import setup, find_packages
 from codecs import open
@@ -15,7 +14,7 @@ import rfclint
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as file:
+with open(path.join(here, 'README.md'), encoding='utf-8') as file:
     long_description = file.read()
     long_description = long_description.replace('\r', '')
 
@@ -58,50 +57,6 @@ class PostInstallCommand(install):
                     return exe_file
         return None
 
-
-def parse(changelog):
-    ver_line = "^([a-z0-9+-]+) \(([^)]+)\)(.*?) *$"
-    sig_line = "^ ?-- ([^<]+) <([^>]+)>  (.*?) *$"
-
-    entries = []
-    if isinstance(changelog, type('')):
-        changelog = open(changelog, mode='rU', encoding='utf-8')
-    for line in changelog:
-        if re.match(ver_line, line):
-            package, version, rest = re.match(ver_line, line).groups()
-            entry = {}
-            entry["package"] = package
-            entry["version"] = version
-            entry["logentry"] = ""
-        elif re.match(sig_line, line):
-            author, email, date = re.match(sig_line, line).groups()
-            entry["author"] = author
-            entry["email"] = email
-            entry["datetime"] = date
-            entry["date"] = " ".join(date.split()[:3])
-
-            entries += [entry]
-        else:
-            entry["logentry"] += line.rstrip() + '\n'
-    changelog.close()
-    return entries
-
-
-changelog_entry_template = """
-Version %(version)s (%(date)s)
-------------------------------------------------
-
-%(logentry)s
-
-"""
-
-long_description += """
-Changelog
-=========
-
-""" + "\n".join([changelog_entry_template % entry for entry in parse("changelog")[:3]])
-
-long_description = long_description.replace('\r', '')
 
 setup(
     name='rfclint',


### PR DESCRIPTION
ran into a problem with python 3.11 not installing this correctly.  Chased it down to some old cruft in setup.py

dumped in a pull request which removes all the changelog parsing and also updated MANIFEST